### PR TITLE
Add white background to general log viewer page

### DIFF
--- a/logs.blade.php
+++ b/logs.blade.php
@@ -5,63 +5,69 @@
 
     {!! $rows->render() !!}
 
-    <div class="table-responsive">
-        <table class="table table-condensed table-hover table-stats">
-            <thead>
-                <tr>
-                    @foreach($headers as $key => $header)
-                    <th class="{{ $key == 'date' ? 'text-left' : 'text-center' }}">
-                        @if ($key == 'date')
-                            <span class="label label-info">{{ $header }}</span>
-                        @else
-                            <span class="level level-{{ $key }}">
-                                {!! log_styler()->icon($key) . ' ' . $header !!}
-                            </span>
-                        @endif
-                    </th>
-                    @endforeach
-                    <th class="text-right">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                @if ($rows->count() > 0)
-                    @foreach($rows as $date => $row)
-                    <tr>
-                        @foreach($row as $key => $value)
-                            <td class="{{ $key == 'date' ? 'text-left' : 'text-center' }}">
+    <div class="box box-default">
+        <div class="box-body">
+        
+            <div class="table-responsive">
+                <table class="table table-condensed table-striped table-hover table-stats">
+                    <thead>
+                        <tr>
+                            @foreach($headers as $key => $header)
+                            <th class="{{ $key == 'date' ? 'text-left' : 'text-center' }}">
                                 @if ($key == 'date')
-                                    <span class="label label-primary">{{ $value }}</span>
-                                @elseif ($value == 0)
-                                    <span class="level level-empty">{{ $value }}</span>
+                                    <span class="label label-info">{{ $header }}</span>
                                 @else
-                                    <a href="{{ route('log-viewer::logs.filter', [$date, $key]) }}">
-                                        <span class="level level-{{ $key }}">{{ $value }}</span>
-                                    </a>
+                                    <span class="level level-{{ $key }}">
+                                        {!! log_styler()->icon($key) . ' ' . $header !!}
+                                    </span>
                                 @endif
-                            </td>
-                        @endforeach
-                        <td class="text-right">
-                            <a href="{{ route('log-viewer::logs.show', [$date]) }}" class="btn btn-xs btn-info">
-                                <i class="fa fa-search"></i>
-                            </a>
-                            <a href="{{ route('log-viewer::logs.download', [$date]) }}" class="btn btn-xs btn-success">
-                                <i class="fa fa-download"></i>
-                            </a>
-                            <a href="#delete-log-modal" class="btn btn-xs btn-danger" data-log-date="{{ $date }}">
-                                <i class="fa fa-trash-o"></i>
-                            </a>
-                        </td>
-                    </tr>
-                    @endforeach
-                @else
-                    <tr>
-                        <td colspan="11" class="text-center">
-                            <span class="label label-default">{{ trans('log-viewer::general.empty-logs') }}</span>
-                        </td>
-                    </tr>
-                @endif
-            </tbody>
-        </table>
+                            </th>
+                            @endforeach
+                            <th class="text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if ($rows->count() > 0)
+                            @foreach($rows as $date => $row)
+                            <tr>
+                                @foreach($row as $key => $value)
+                                    <td class="{{ $key == 'date' ? 'text-left' : 'text-center' }}">
+                                        @if ($key == 'date')
+                                            <span class="label label-primary">{{ $value }}</span>
+                                        @elseif ($value == 0)
+                                            <span class="level level-empty">{{ $value }}</span>
+                                        @else
+                                            <a href="{{ route('log-viewer::logs.filter', [$date, $key]) }}">
+                                                <span class="level level-{{ $key }}">{{ $value }}</span>
+                                            </a>
+                                        @endif
+                                    </td>
+                                @endforeach
+                                <td class="text-right">
+                                    <a href="{{ route('log-viewer::logs.show', [$date]) }}" class="btn btn-xs btn-info">
+                                        <i class="fa fa-search"></i>
+                                    </a>
+                                    <a href="{{ route('log-viewer::logs.download', [$date]) }}" class="btn btn-xs btn-success">
+                                        <i class="fa fa-download"></i>
+                                    </a>
+                                    <a href="#delete-log-modal" class="btn btn-xs btn-danger" data-log-date="{{ $date }}">
+                                        <i class="fa fa-trash-o"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                            @endforeach
+                        @else
+                            <tr>
+                                <td colspan="11" class="text-center">
+                                    <span class="label label-default">{{ trans('log-viewer::general.empty-logs') }}</span>
+                                </td>
+                            </tr>
+                        @endif
+                    </tbody>
+                </table>
+            </div>
+            
+        </div>
     </div>
 
     {!! $rows->render() !!}


### PR DESCRIPTION
Ok so this looks like a lot more changes that are actually there :-)

<img width="1440" alt="screen shot 2017-09-11 at 14 53 55" src="https://user-images.githubusercontent.com/1032474/30273300-1a58fffc-9701-11e7-8b9f-acd0dc120953.png">
vs
<img width="1440" alt="screen shot 2017-09-11 at 14 54 10" src="https://user-images.githubusercontent.com/1032474/30273303-1e7d8bca-9701-11e7-8a91-0c42bda39b50.png">


It's definitely a matter of opinion and taste, but I like it more when there's a white background to the main view. So the only thing I did in this PR is add the ```.box``` and ```.box-body``` divs and add the ```table-striped``` class to the table. It just looks like a lot more because I've indented the rest to match the new divs.

Hope you like it. If you don't I totally understand that too. Keep up the good work. Cheers!